### PR TITLE
Add configuration option for enabled filetypes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # coc-vimtex
 
-Tex completion source use [vimtex](https://github.com/lervag/vimtex).
+Tex completion source for [vimtex](https://github.com/lervag/vimtex).
 
 ## Install
 
@@ -18,6 +18,7 @@ Or add this plugin's folder to your vim's runtimepath.
 - `coc.source.vimtex.enable` set to false to disable this source.
 - `coc.source.vimtex.priority` priority of source, default `99`.
 - `coc.source.vimtex.shortcut` shortcut used in `menu` of completion item.
+- `coc.source.vimtex.filetypes` Filetypes to enable this source for. Defaults to `['tex', 'plaintex', 'latex']`. Useful for when you want to enable vimtex completions for markdown/pandoc files
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "activationEvents": [
     "onLanguage:tex",
     "onLanguage:plaintex",
-    "onLanguage:latex"
+    "onLanguage:latex",
+    "onLanguage:markdown",
+    "onLanguage:pandoc"
   ],
   "contributes": {
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
         "coc.source.vimtex.priority": {
           "type": "integer",
           "default": 99
+        },
+        "coc.source.vimtex.filetypes": {
+          "type": "array",
+          "default": ["tex", "plaintex", "latex"]
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ exports.activate = async context => {
     name: 'vimtex',
     enable: config.get('enable', true),
     priority: config.get('priority', 99),
-    filetypes: ['tex', 'plaintex', 'latex', 'markdown', 'pandoc'],
+    filetypes: config.get('filetypes', ['tex', 'latex', 'plaintex']),
     sourceType: SourceType.Remote,
     triggerPatterns: [pattern],
     doComplete: async opt => {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ exports.activate = async context => {
     name: 'vimtex',
     enable: config.get('enable', true),
     priority: config.get('priority', 99),
-    filetypes: ['tex', 'plaintex', 'latex'],
+    filetypes: ['tex', 'plaintex', 'latex', 'markdown', 'pandoc'],
     sourceType: SourceType.Remote,
     triggerPatterns: [pattern],
     doComplete: async opt => {


### PR DESCRIPTION
Add `coc.sources.vimtex.filetypes` configuration paramter so that users can enable this for non-latex filetypes e.g. markdown.

This allows for you to get latex autocompletion and features with `coc.nvim` in markdown/pandoc/other files, which is really useful. You just need to add `call vimtex#init()` to the `ftplugin` file for the filetype you want to enable this for as well.




